### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#Jesus.js#
+# Jesus.js #
 Not sure what will it do yet. But it just sounds like a really powerful library no matter what it does.
 
-##API##
+## API ##
 	//The global variable Jesus will be removed and be back in 3 days.
 	Jesus.die();
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
