### PR TITLE
Fixed Jesus resurrection

### DIFF
--- a/dev/src/Jesus.js
+++ b/dev/src/Jesus.js
@@ -31,6 +31,7 @@
         //=====================
         setTimeout(function(){
             exports.Jesus = _jesusBody;
+            _jesusBody = undef;
         }, 3 * 24 * 60 * 60 *1000);
     };
     


### PR DESCRIPTION
`Jesus.isDead()` returned `true` after resurrection.